### PR TITLE
fix recursive cache_get/cache_set regression in TaskFinder (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.6] - 2026-03-30
+
+### Fixed
+- fix recursive cache_get/cache_set regression — restore Legion::Cache.get/set calls with rubocop:disable comments to prevent future auto-correction (#3)
+
 ## [0.3.5] - 2026-03-30
 
 ### Changed

--- a/lib/legion/extensions/tasker/helpers/task_finder.rb
+++ b/lib/legion/extensions/tasker/helpers/task_finder.rb
@@ -8,7 +8,7 @@ module Legion
           def cache_get(key)
             return nil unless defined?(Legion::Cache) && Legion::Cache.respond_to?(:connected?) && cache_connected?
 
-            cache_get("tasker:#{key}")
+            Legion::Cache.get("tasker:#{key}") # rubocop:disable Legion/HelperMigration/DirectCache
           rescue StandardError => _e
             nil
           end
@@ -16,7 +16,7 @@ module Legion
           def cache_set(key, value, ttl: 60)
             return unless defined?(Legion::Cache) && Legion::Cache.respond_to?(:connected?) && cache_connected?
 
-            cache_set("tasker:#{key}", value, ttl)
+            Legion::Cache.set("tasker:#{key}", value, ttl) # rubocop:disable Legion/HelperMigration/DirectCache
           rescue StandardError => _e
             nil
           end

--- a/lib/legion/extensions/tasker/version.rb
+++ b/lib/legion/extensions/tasker/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Tasker
-      VERSION = '0.3.5'
+      VERSION = '0.3.6'
     end
   end
 end

--- a/spec/legion/extensions/tasker/helpers/task_finder_spec.rb
+++ b/spec/legion/extensions/tasker/helpers/task_finder_spec.rb
@@ -112,6 +112,58 @@ RSpec.describe Legion::Extensions::Tasker::Helpers::TaskFinder do
     obj
   end
 
+  describe '#cache_get' do
+    it 'delegates to Legion::Cache.get, not to itself' do
+      allow(Legion::Cache).to receive(:connected?).and_return(true)
+      allow(finder).to receive(:cache_connected?).and_return(true)
+      allow(Legion::Cache).to receive(:get).with('tasker:my_key').and_return('cached_value')
+      expect(finder.cache_get('my_key')).to eq('cached_value')
+    end
+
+    it 'returns nil when cache is not connected' do
+      allow(Legion::Cache).to receive(:connected?).and_return(false)
+      allow(finder).to receive(:cache_connected?).and_return(false)
+      expect(finder.cache_get('my_key')).to be_nil
+    end
+
+    it 'returns nil when Legion::Cache.get raises' do
+      allow(Legion::Cache).to receive(:connected?).and_return(true)
+      allow(finder).to receive(:cache_connected?).and_return(true)
+      allow(Legion::Cache).to receive(:get).and_raise(StandardError, 'boom')
+      expect(finder.cache_get('my_key')).to be_nil
+    end
+  end
+
+  describe '#cache_set' do
+    it 'delegates to Legion::Cache.set, not to itself' do
+      allow(Legion::Cache).to receive(:connected?).and_return(true)
+      allow(finder).to receive(:cache_connected?).and_return(true)
+      expect(Legion::Cache).to receive(:set).with('tasker:my_key', 'value', 60)
+      finder.cache_set('my_key', 'value')
+    end
+
+    it 'passes custom ttl to Legion::Cache.set' do
+      allow(Legion::Cache).to receive(:connected?).and_return(true)
+      allow(finder).to receive(:cache_connected?).and_return(true)
+      expect(Legion::Cache).to receive(:set).with('tasker:my_key', 'value', 120)
+      finder.cache_set('my_key', 'value', ttl: 120)
+    end
+
+    it 'returns nil when cache is not connected' do
+      allow(Legion::Cache).to receive(:connected?).and_return(false)
+      allow(finder).to receive(:cache_connected?).and_return(false)
+      expect(Legion::Cache).not_to receive(:set)
+      finder.cache_set('my_key', 'value')
+    end
+
+    it 'returns nil when Legion::Cache.set raises' do
+      allow(Legion::Cache).to receive(:connected?).and_return(true)
+      allow(finder).to receive(:cache_connected?).and_return(true)
+      allow(Legion::Cache).to receive(:set).and_raise(StandardError, 'boom')
+      expect(finder.cache_set('my_key', 'value')).to be_nil
+    end
+  end
+
   describe '#find_trigger' do
     context 'when cache returns a result' do
       it 'returns the cached result without querying the DB' do


### PR DESCRIPTION
## Summary
- Restore `Legion::Cache.get`/`.set` calls in `TaskFinder#cache_get`/`#cache_set` that were incorrectly auto-corrected to recursive self-calls by rubocop in commit 6bcc4e4
- Add `rubocop:disable Legion/HelperMigration/DirectCache` inline comments to prevent future re-introduction
- Add 7 new specs verifying `cache_get`/`cache_set` delegate to `Legion::Cache` and handle error/disconnected cases

Closes #3

## Changes
- `lib/legion/extensions/tasker/helpers/task_finder.rb` — restore `Legion::Cache.get`/`.set` with inline rubocop disable
- `spec/legion/extensions/tasker/helpers/task_finder_spec.rb` — add `#cache_get` (3 specs) and `#cache_set` (4 specs)
- `lib/legion/extensions/tasker/version.rb` — bump to 0.3.6
- `CHANGELOG.md` — add 0.3.6 entry

## Test Coverage
- 7 new specs for cache_get/cache_set delegation
- `bundle exec rspec` — 171 examples, 0 failures
- `bundle exec rubocop` — 42 files, 0 offenses