### PR TITLE
fix cache type guards in check_subtask and task_finder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.8] - 2026-03-31
+
+### Fixed
+- type guard cache returns in `find_trigger` (must be Hash) and `find_subtasks` (must be Array) — cache deserialization can return String instead of Hash, causing `TypeError: no implicit conversion of Symbol into Integer`
+- `check_subtasks` guard changed from `unless trigger` to `unless trigger.is_a?(Hash)` for same reason
+
 ## [0.3.7] - 2026-03-30
 
 ### Fixed

--- a/lib/legion/extensions/tasker/helpers/task_finder.rb
+++ b/lib/legion/extensions/tasker/helpers/task_finder.rb
@@ -26,7 +26,7 @@ module Legion
 
             cache_key = "find_trigger:#{runner_class}:#{function}"
             cached = cache_get(cache_key)
-            return cached unless cached.nil?
+            return cached if cached.is_a?(Hash)
 
             result = Legion::Data::Model::Function
                      .join(:runners, id: :runner_id)
@@ -46,7 +46,7 @@ module Legion
 
             cache_key = "find_subtasks:#{trigger_id}"
             cached = cache_get(cache_key)
-            return cached unless cached.nil?
+            return cached if cached.is_a?(Array)
 
             results = subtask_query(trigger_id).all.map do |row|
               row[:runner_routing_key] = "#{row[:exchange]}.#{row[:queue]}.#{row[:function]}"

--- a/lib/legion/extensions/tasker/runners/check_subtask.rb
+++ b/lib/legion/extensions/tasker/runners/check_subtask.rb
@@ -12,7 +12,7 @@ module Legion
 
           def check_subtasks(runner_class:, function:, **opts)
             trigger = find_trigger(runner_class: runner_class, function: function)
-            return { success: true, subtasks: 0 } unless trigger
+            return { success: true, subtasks: 0 } unless trigger.is_a?(Hash)
 
             find_subtasks(trigger_id: trigger[:function_id]).each do |relationship|
               next unless chain_matches?(relationship, opts)

--- a/lib/legion/extensions/tasker/version.rb
+++ b/lib/legion/extensions/tasker/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Tasker
-      VERSION = '0.3.7'
+      VERSION = '0.3.8'
     end
   end
 end


### PR DESCRIPTION
## Summary
- Cache deserialization can return String instead of Hash/Array, causing `TypeError: no implicit conversion of Symbol into Integer` in `check_subtasks`
- `find_trigger` now requires cached value to be a Hash before returning it
- `find_subtasks` now requires cached value to be an Array before returning it
- `check_subtasks` guard changed from truthiness check to `is_a?(Hash)`

## Test plan
- [x] 171 specs passing, 0 failures
- [x] 0 rubocop offenses