### PR TITLE
Fleet WS-00A: fix transformer routing key

### DIFF
--- a/lib/legion/extensions/tasker/runners/check_subtask.rb
+++ b/lib/legion/extensions/tasker/runners/check_subtask.rb
@@ -49,7 +49,7 @@ module Legion
             if relationship[:conditions].is_a?(String) && relationship[:conditions].length > 4
               'task.subtask.conditioner'
             elsif relationship[:transformation].is_a?(String) && relationship[:transformation].length > 4
-              'task.subtask.transformation'
+              'task.subtask.transform'
             else
               relationship[:runner_routing_key]
             end

--- a/lib/legion/extensions/tasker/runners/fetch_delayed.rb
+++ b/lib/legion/extensions/tasker/runners/fetch_delayed.rb
@@ -46,7 +46,7 @@ module Legion
             if task[:conditions].is_a?(String) && task[:conditions].length > 4
               'task.subtask.conditioner'
             elsif task[:transformation].is_a?(String) && task[:transformation].length > 4
-              'task.subtask.transformation'
+              'task.subtask.transform'
             else
               task[:runner_routing_key]
             end
@@ -55,7 +55,7 @@ module Legion
           def update_delayed_status(task_id, routing_key)
             status = case routing_key
                      when 'task.subtask.conditioner' then 'conditioner.queued'
-                     when 'task.subtask.transformation' then 'transformer.queued'
+                     when 'task.subtask.transform' then 'transformer.queued'
                      else 'task.queued'
                      end
             task_update(task_id, status)

--- a/lib/legion/extensions/tasker/version.rb
+++ b/lib/legion/extensions/tasker/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Tasker
-      VERSION = '0.3.8'
+      VERSION = '0.3.9'
     end
   end
 end

--- a/spec/legion/extensions/check_subtask_spec.rb
+++ b/spec/legion/extensions/check_subtask_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe 'CheckSubtask pure logic' do
 
     it 'returns transformation key when transformation present but no conditions' do
       relationship = { conditions: nil, transformation: '{"key":"<%= val %>"}', runner_routing_key: 'ext.runner.func' }
-      expect(test_obj.subtask_routing_key(relationship)).to eq('task.subtask.transformation')
+      expect(test_obj.subtask_routing_key(relationship)).to eq('task.subtask.transform')
     end
 
     it 'returns runner routing key when neither conditions nor transformation' do

--- a/spec/legion/extensions/tasker/runners/check_subtask_spec.rb
+++ b/spec/legion/extensions/tasker/runners/check_subtask_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Stub transport dependency required at load time by check_subtask.rb
+$LOADED_FEATURES << 'legion/transport/messages/subtask' unless $LOADED_FEATURES.include?('legion/transport/messages/subtask')
+
+module Legion
+  module Extensions
+    module Tasker
+      module Helpers
+        module TaskFinder; end unless defined?(Legion::Extensions::Tasker::Helpers::TaskFinder)
+      end
+    end
+  end
+end
+
+require 'legion/extensions/tasker/runners/check_subtask'
+
+RSpec.describe Legion::Extensions::Tasker::Runners::CheckSubtask do
+  let(:test_class) do
+    Class.new do
+      include Legion::Extensions::Tasker::Runners::CheckSubtask
+    end
+  end
+
+  subject { test_class.new }
+
+  describe '#subtask_routing_key' do
+    context 'when relationship has conditions' do
+      it 'routes to conditioner' do
+        relationship = { conditions: '{"all":[{"fact":"x","operator":"equal","value":1}]}', transformation: nil }
+        expect(subject.subtask_routing_key(relationship)).to eq('task.subtask.conditioner')
+      end
+    end
+
+    context 'when relationship has transformation but no conditions' do
+      it 'routes to task.subtask.transform' do
+        relationship = { conditions: nil, transformation: '{"template":"<%= results %>"}' }
+        expect(subject.subtask_routing_key(relationship)).to eq('task.subtask.transform')
+      end
+    end
+
+    context 'when relationship has neither conditions nor transformation' do
+      it 'routes to the runner routing key' do
+        relationship = { conditions: nil, transformation: nil, runner_routing_key: 'lex.planner.runners.planner.plan' }
+        expect(subject.subtask_routing_key(relationship)).to eq('lex.planner.runners.planner.plan')
+      end
+    end
+  end
+end

--- a/spec/legion/extensions/tasker/runners/fetch_delayed_routing_key_spec.rb
+++ b/spec/legion/extensions/tasker/runners/fetch_delayed_routing_key_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Legion
+  module Extensions
+    module Helpers
+      module Task; end unless defined?(Legion::Extensions::Helpers::Task)
+    end
+
+    module Tasker
+      module Helpers
+        module TaskFinder; end unless defined?(Legion::Extensions::Tasker::Helpers::TaskFinder)
+      end
+
+      module Transport
+        module Messages
+          unless defined?(Legion::Extensions::Tasker::Transport::Messages::FetchDelayed)
+            class FetchDelayed
+              def initialize(**); end
+              def publish; end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  module Transport
+    module Messages
+      unless defined?(Legion::Transport::Messages::Task)
+        class Task
+          def initialize(**); end
+          def publish; end
+        end
+      end
+    end
+  end
+end
+
+require 'legion/extensions/tasker/runners/fetch_delayed'
+
+RSpec.describe Legion::Extensions::Tasker::Runners::FetchDelayed do
+  let(:test_class) do
+    Class.new do
+      include Legion::Extensions::Tasker::Runners::FetchDelayed
+
+      def log
+        @log ||= Class.new { def debug(*); end }.new
+      end
+
+      def task_update(task_id, status); end
+    end
+  end
+
+  subject { test_class.new }
+
+  describe '#delayed_routing_key' do
+    context 'when task has conditions' do
+      it 'routes to conditioner' do
+        task = { conditions: '{"all":[{"fact":"x","operator":"equal","value":1}]}', transformation: nil }
+        expect(subject.delayed_routing_key(task)).to eq('task.subtask.conditioner')
+      end
+    end
+
+    context 'when task has transformation but no conditions' do
+      it 'routes to task.subtask.transform' do
+        task = { conditions: nil, transformation: '{"template":"<%= results %>"}' }
+        expect(subject.delayed_routing_key(task)).to eq('task.subtask.transform')
+      end
+    end
+
+    context 'when task has neither conditions nor transformation' do
+      it 'routes to the runner routing key' do
+        task = { conditions: nil, transformation: nil, runner_routing_key: 'lex.developer.runners.developer.implement' }
+        expect(subject.delayed_routing_key(task)).to eq('lex.developer.runners.developer.implement')
+      end
+    end
+  end
+
+  describe '#update_delayed_status' do
+    it 'maps task.subtask.transform to transformer.queued' do
+      allow(subject).to receive(:task_update)
+      subject.update_delayed_status(1, 'task.subtask.transform')
+      expect(subject).to have_received(:task_update).with(1, 'transformer.queued')
+    end
+  end
+end

--- a/spec/legion/extensions/tasker/runners/fetch_delayed_spec.rb
+++ b/spec/legion/extensions/tasker/runners/fetch_delayed_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Legion::Extensions::Tasker::Runners::FetchDelayed do
 
     it 'returns transformation key when transformation present but no conditions' do
       task = { conditions: nil, transformation: '{"key":"<%= val %>"}', runner_routing_key: 'ext.runner.func' }
-      expect(runner.delayed_routing_key(task)).to eq('task.subtask.transformation')
+      expect(runner.delayed_routing_key(task)).to eq('task.subtask.transform')
     end
 
     it 'returns runner routing key when neither conditions nor transformation' do
@@ -124,7 +124,7 @@ RSpec.describe Legion::Extensions::Tasker::Runners::FetchDelayed do
 
     it 'sets status to transformer.queued for transformation routing key' do
       expect(runner).to receive(:task_update).with(2, 'transformer.queued')
-      runner.update_delayed_status(2, 'task.subtask.transformation')
+      runner.update_delayed_status(2, 'task.subtask.transform')
     end
 
     it 'sets status to task.queued for any other routing key' do


### PR DESCRIPTION
## Summary

- Fixes routing key mismatch in `CheckSubtask#subtask_routing_key` and `FetchDelayed#delayed_routing_key`: `task.subtask.transformation` → `task.subtask.transform`
- Fixes `FetchDelayed#update_delayed_status` case to match the corrected key
- The transformer listens on `task.subtask.transform`; the wrong key meant it never received messages from tasker

## Test plan

- [x] New spec `spec/legion/extensions/tasker/runners/check_subtask_spec.rb` — 3 examples covering conditioner, transform, and runner routing key paths
- [x] New spec `spec/legion/extensions/tasker/runners/fetch_delayed_routing_key_spec.rb` — 4 examples including `update_delayed_status` mapping
- [x] Updated pre-existing assertions in `check_subtask_spec.rb` and `fetch_delayed_spec.rb` that encoded the old buggy value
- [x] Full suite: 178 examples, 0 failures
- [x] Rubocop: 0 offenses