### PR TITLE
Fleet WS-00H: fix cache_set TTL as keyword arg

### DIFF
--- a/lib/legion/extensions/tasker/helpers/task_finder.rb
+++ b/lib/legion/extensions/tasker/helpers/task_finder.rb
@@ -16,7 +16,7 @@ module Legion
           def cache_set(key, value, ttl: 60)
             return unless defined?(Legion::Cache) && Legion::Cache.respond_to?(:connected?) && cache_connected?
 
-            Legion::Cache.set("tasker:#{key}", value, ttl) # rubocop:disable Legion/HelperMigration/DirectCache
+            Legion::Cache.set("tasker:#{key}", value, ttl: ttl) # rubocop:disable Legion/HelperMigration/DirectCache
           rescue StandardError => _e
             nil
           end

--- a/lib/legion/extensions/tasker/version.rb
+++ b/lib/legion/extensions/tasker/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Tasker
-      VERSION = '0.3.8'
+      VERSION = '0.3.9'
     end
   end
 end

--- a/spec/legion/extensions/tasker/helpers/task_finder_spec.rb
+++ b/spec/legion/extensions/tasker/helpers/task_finder_spec.rb
@@ -135,17 +135,17 @@ RSpec.describe Legion::Extensions::Tasker::Helpers::TaskFinder do
   end
 
   describe '#cache_set' do
-    it 'delegates to Legion::Cache.set, not to itself' do
+    it 'delegates to Legion::Cache.set with keyword ttl' do
       allow(Legion::Cache).to receive(:connected?).and_return(true)
       allow(finder).to receive(:cache_connected?).and_return(true)
-      expect(Legion::Cache).to receive(:set).with('tasker:my_key', 'value', 60)
+      expect(Legion::Cache).to receive(:set).with('tasker:my_key', 'value', ttl: 60)
       finder.cache_set('my_key', 'value')
     end
 
-    it 'passes custom ttl to Legion::Cache.set' do
+    it 'passes custom ttl as keyword to Legion::Cache.set' do
       allow(Legion::Cache).to receive(:connected?).and_return(true)
       allow(finder).to receive(:cache_connected?).and_return(true)
-      expect(Legion::Cache).to receive(:set).with('tasker:my_key', 'value', 120)
+      expect(Legion::Cache).to receive(:set).with('tasker:my_key', 'value', ttl: 120)
       finder.cache_set('my_key', 'value', ttl: 120)
     end
 


### PR DESCRIPTION
## Summary

- **Bug:** `TaskFinder#cache_set` called `Legion::Cache.set(key, value, ttl)` with TTL as a positional argument. `Legion::Cache.set` (Redis driver) takes TTL as a keyword (`ttl:`). Positional TTL was silently ignored — cached tasker keys never expired.
- **Fix:** Change to `Legion::Cache.set(key, value, ttl: ttl)`.
- **Test:** Updated `task_finder_spec.rb` to assert `with('tasker:key', value, ttl: 60)` (keyword), correctly failing before the fix.

## Test plan

- [ ] `bundle exec rspec spec/legion/extensions/tasker/helpers/task_finder_spec.rb` — 16 examples, 0 failures
- [ ] `bundle exec rubocop lib/legion/extensions/tasker/helpers/task_finder.rb` — 0 offenses