### PR TITLE
Fleet WS-04: select engine from relationship in TaskFinder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.10] - 2026-04-13
+
+### Added
+- Select `engine` column from `relationships` in `TaskFinder#subtask_query` — propagates engine selection through `build_task_hash` to SubTask dispatch
+
+## [0.3.9] - 2026-03-31
+
+### Fixed
+- Version bump from previous branch (fleet/ws-00h runner fixes)
+
 ## [0.3.8] - 2026-03-31
 
 ### Fixed

--- a/lib/legion/extensions/tasker/helpers/task_finder.rb
+++ b/lib/legion/extensions/tasker/helpers/task_finder.rb
@@ -104,6 +104,7 @@ module Legion
                 Sequel[:relationships][:action_id],
                 Sequel[:relationships][:conditions],
                 Sequel[:relationships][:transformation],
+                Sequel[:relationships][:engine],
                 Sequel[:runners][:namespace],
                 Sequel[:runners][:id].as(:runner_id),
                 Sequel[:runners][:queue],

--- a/lib/legion/extensions/tasker/version.rb
+++ b/lib/legion/extensions/tasker/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Tasker
-      VERSION = '0.3.9'
+      VERSION = '0.3.10'
     end
   end
 end

--- a/spec/legion/extensions/tasker/helpers/task_finder_engine_spec.rb
+++ b/spec/legion/extensions/tasker/helpers/task_finder_engine_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sequel'
+require 'legion/extensions/tasker/helpers/task_finder'
+
+RSpec.describe Legion::Extensions::Tasker::Helpers::TaskFinder do
+  let(:test_class) do
+    Class.new do
+      include Legion::Extensions::Tasker::Helpers::TaskFinder
+
+      def cache_connected?
+        false
+      end
+    end
+  end
+
+  subject { test_class.new }
+
+  describe '#subtask_query result includes engine' do
+    before do
+      # Create in-memory DB with needed tables
+      @db = Sequel.sqlite
+      @db.create_table(:extensions) do
+        primary_key :id
+        String :exchange
+      end
+      @db.create_table(:runners) do
+        primary_key :id
+        foreign_key :extension_id, :extensions
+        String :namespace
+        String :queue
+      end
+      @db.create_table(:functions) do
+        primary_key :id
+        foreign_key :runner_id, :runners
+        String :name
+      end
+      @db.create_table(:relationships) do
+        primary_key :id
+        foreign_key :trigger_id, :functions
+        foreign_key :action_id, :functions
+        TrueClass :active, default: true
+        TrueClass :debug, default: false
+        TrueClass :allow_new_chains, default: false
+        Integer :delay, default: 0
+        Integer :chain_id
+        String :conditions, text: true
+        String :transformation, text: true
+        String :engine, size: 50
+      end
+
+      # Seed data
+      ext_id = @db[:extensions].insert(exchange: 'lex.transformer')
+      runner_id = @db[:runners].insert(extension_id: ext_id, namespace: 'Transform', queue: 'runners.transform')
+      trigger_fn_id = @db[:functions].insert(runner_id: runner_id, name: 'assess')
+      action_fn_id = @db[:functions].insert(runner_id: runner_id, name: 'transform')
+
+      @db[:relationships].insert(
+        trigger_id:     trigger_fn_id,
+        action_id:      action_fn_id,
+        active:         true,
+        engine:         'llm',
+        transformation: '{"prompt":"summarize feedback"}'
+      )
+
+      stub_const('Legion::Data::Model::Relationship', @db[:relationships])
+    end
+
+    it 'includes engine in the finder result' do
+      trigger_row = @db[:functions].first
+      result = subject.find_subtasks(trigger_id: trigger_row[:id])
+      expect(result.first).to have_key(:engine)
+      expect(result.first[:engine]).to eq('llm')
+    end
+  end
+end

--- a/spec/legion/extensions/tasker/runners/check_subtask_spec.rb
+++ b/spec/legion/extensions/tasker/runners/check_subtask_spec.rb
@@ -48,4 +48,20 @@ RSpec.describe Legion::Extensions::Tasker::Runners::CheckSubtask do
       end
     end
   end
+
+  describe '#build_task_hash' do
+    it 'includes engine from the relationship' do
+      relationship = {
+        delay:              0,
+        conditions:         nil,
+        transformation:     '{"template":"test"}',
+        engine:             'llm',
+        runner_routing_key: 'lex.transformer.runners.transform.transform'
+      }
+      opts = { task_id: 1 }
+
+      task_hash = subject.build_task_hash(relationship, opts)
+      expect(task_hash[:engine]).to eq('llm')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds `engine` to the `.select(...)` list in `TaskFinder#subtask_query`
- Verifies `engine` propagates through `CheckSubtask#build_task_hash` automatically (via `relationship.dup`)

## Motivation

The `relationships` table now has an `engine` column (legion-data migration 071). Without selecting it in `subtask_query`, the value is silently dropped before it ever reaches the SubTask message.

## Changes

- `lib/legion/extensions/tasker/helpers/task_finder.rb` — adds `Sequel[:relationships][:engine]` after `Sequel[:relationships][:transformation]` in the select list
- `spec/legion/extensions/tasker/helpers/task_finder_engine_spec.rb` (new) — in-memory SQLite test verifying `find_subtasks` returns `engine` in results
- `spec/legion/extensions/tasker/runners/check_subtask_spec.rb` — appended `#build_task_hash` test confirming engine propagates via `relationship.dup`

## Depends On

- LegionIO/legion-data#27 — migration 071 (engine column)
- LegionIO/legion-transport#26 — SubTask engine field

## Merge Order

**Merge third** — after legion-data and legion-transport.

## Test Plan

- [ ] `bundle exec rspec` — 180 examples, 0 failures
- [ ] Part of fleet WS-04